### PR TITLE
Husky2 (lint-staged)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "browser": true,
     "es6": true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,11 @@
+
+import { relative } from 'path'
+
+const buildEslintCommand = (filenames) =>
+  `next lint --fix --file ${filenames
+    .map((f) => relative(process.cwd(), f))
+    .join(' --file ')}`
+
+export default {
+  '*.{js,jsx,ts,tsx}': [buildEslintCommand],
+}

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,6 @@
+ {
+    "*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "npm run lint:fix"
+    ]
+  }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,0 @@
- {
-    "*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "npm run lint:fix"
-    ]
-  }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "printWidth": 100,
   "bracketSpacing": true,
   "jsxBracketSameLine": false,

--- a/checkers/components/Home/BoardCheckers.tsx
+++ b/checkers/components/Home/BoardCheckers.tsx
@@ -44,6 +44,7 @@ const BoardCheckers: FC<BoardProps> = ({
   let directionEmptyTwo = selectedCell?.figure?.color === Colors.BLACK ? 1 : -1;
 
   const { isPlayWithBoot, idForPlayersOnline } = useSelector((state: any) => state.checkers);
+
   const click = (cell: Cell) => {
     let banOnHitting = true;
     let ok = 0;

--- a/checkers/components/Home/BoardCheckers.tsx
+++ b/checkers/components/Home/BoardCheckers.tsx
@@ -1,5 +1,4 @@
 import { useSelector } from 'react-redux';
-
 import React, { FC, useEffect, useState } from 'react';
 import Link from 'next/link';
 
@@ -9,7 +8,7 @@ import { Colors } from '../../model/Colors';
 import { Player } from '../../model/Player';
 import { Figure } from '../../model/figures/Figure';
 import Modal from '../Modal/Modal';
-import { RootState } from '../../../store';
+// import { RootState } from '../../../store'; // заменила на any тк был конфликт.
 import { players } from '../Lobbi/PlayersForOnlinePlay';
 
 import CellComponent from './CellComponent';
@@ -44,7 +43,7 @@ const BoardCheckers: FC<BoardProps> = ({
   let directionEmpty = selectedCell?.figure?.color === Colors.BLACK ? -1 : 1;
   let directionEmptyTwo = selectedCell?.figure?.color === Colors.BLACK ? 1 : -1;
 
-  const { isPlayWithBoot, idForPlayersOnline } = useSelector((state: RootState) => state.checkers);
+  const { isPlayWithBoot, idForPlayersOnline } = useSelector((state: any) => state.checkers);
 
   const click = (cell: Cell) => {
     let banOnHitting = true;

--- a/checkers/components/Home/BoardCheckers.tsx
+++ b/checkers/components/Home/BoardCheckers.tsx
@@ -44,7 +44,6 @@ const BoardCheckers: FC<BoardProps> = ({
   let directionEmptyTwo = selectedCell?.figure?.color === Colors.BLACK ? 1 : -1;
 
   const { isPlayWithBoot, idForPlayersOnline } = useSelector((state: any) => state.checkers);
-
   const click = (cell: Cell) => {
     let banOnHitting = true;
     let ok = 0;

--- a/chess/src/components/chess/chess.module.scss
+++ b/chess/src/components/chess/chess.module.scss
@@ -89,7 +89,7 @@
   &-item{
     display: flex;
     align-items: center;
-    justify-content: start;
+    justify-content: flex-start;
     margin-bottom: 5px;
   }
   &-image{

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "env FORCE_COLOR=1 lint-staged"
     }
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "**/*.{js,jsx,ts,tsx}": [
       "prettier --write",
       "npm run lint:fix"
     ]

--- a/package.json
+++ b/package.json
@@ -2,11 +2,15 @@
   "name": "host-app",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix",
+    "prepare": "husky install",
+    "pre-commit": "lint-staged"
   },
   "dependencies": {
     "@next/eslint-plugin-next": "^13.0.3",
@@ -14,6 +18,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@types/react-transition-group": "^4.4.5",
     "axios": "^1.1.2",
     "classnames": "^2.3.2",
     "next": "12.2.2",
@@ -52,5 +57,16 @@
     "prettier": "^2.7.1",
     "sass": "^1.55.0",
     "typescript": "^4.8.4"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "npm run lint:fix"
+    ]
   }
 }


### PR DESCRIPTION
1. сделан git pull origin main после мерджа комита Алины.
2. функционал в ветках main & husky2 в браузере работает 100% (стили у шахмат несколько раз рандомно упали \ восстановились).
3. в husky2 добавлен коммит по хаски и линтеру из прежней ветки husky-lint (последняя будет впоследствии удалена).
4. в шашках в "checkers/components/Home/BoardCheckers.tsx" закоммичена стр. 11 - был конфликт. Необходимо будет потом исправить в самой игре.
5. небольшая замена со start на flex-start в "chess/src/components/chess/chess.module.scss" (был конфликт).
6. добавлены скрипты по lint-staged, хук pre-commit.